### PR TITLE
Update license identifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Use Blueprint in Rust GTK applications"
 version = "0.2.0"
 repository = "https://github.com/Megadash452/gtk-blueprint"
 readme = "README.md"
-license = "GPL-3.0"
+license = "GPL-3.0-or-later"
 keywords = ["gtk", "blueprint"]
 edition = "2021"
 


### PR DESCRIPTION
`GPL-3.0` is a deprecated identifier per https://spdx.org/licenses/#deprecated

Assuming you meant GPL 3.0 or later, this PR updates it accordingly.